### PR TITLE
Add support for volume inc/dec via tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,18 +40,23 @@ spotify:
 tags:
   00000044886655661122: "spotify:playlist:43nVldajDhG1YVwZKxVh"
   00000011559977882233: "https://open.spotify.com/album/7LQhG0xSDjFiKJnziyB3Zj?si=eFQbWbq0Q16q6Go8tjlCvw"
-  00000011666611330099: "RESUME"
   00000044772255668800: "https://open.spotify.com/album/5N73vwGXol4maS9U6HLp0o?si=oWBQKSpWReuOPnr50ayWSw"
   00000044772255668800: "PAUSE"
+  00000011666611330099: "RESUME"
+  00000011666611330100: "VOLUME_INCREASE"
+  00000011666611330101: "VOLUME_DECREASE"
 ```
 
 The `input_device_description` is either a path to an input device (eg. `/dev/input/event15`) or
 a string with the device name (try `sudo evtest` to find out what device name the RFID Reader has).
 For Spotify, `username` and `password` must be given.
 The `tags` section maps the keys (which come from the input device) to an action. The action
-can be either some spotify URI or some special actions. Currently, there is `PAUSE` (which pause
-the current `soundkid-player` process) or `RESUME` (which resume the paused `soundkid-player`
-process.
+can be either some spotify URI or some special actions. Currently there are the following special actions:
+
+- `PAUSE`: pause the current `soundkid-player` process
+- `RESUME` which resume the paused `soundkid-player` process
+- `VOLUME_INCREASE` increase the volume by 5%
+- `VOLUME_DECREASE` decrease the volume by 5%
 
 ## Debugging
 Build the project with:

--- a/src/bin/soundkid.rs
+++ b/src/bin/soundkid.rs
@@ -62,6 +62,10 @@ fn main() {
                 pause(&mut child);
             } else if conf.tags.get(&received).unwrap() == "RESUME" {
                 resume(&mut child);
+            } else if conf.tags.get(&received).unwrap() == "VOLUME_INCREASE" {
+                volume_increase();
+            } else if conf.tags.get(&received).unwrap() == "VOLUME_DECREASE" {
+                volume_decrease();
             } else {
                 play(&mut child, &conf, &received);
             }
@@ -85,6 +89,24 @@ fn resume(child: &mut Option<Child>) {
         info!("Resume process with PID {:?}", x.id());
         signal::kill(Pid::from_raw(x.id() as i32), Signal::SIGCONT).unwrap();
     }
+}
+
+/// increase the volume via alsa
+fn volume_increase() {
+    // FIXME: do not hardcode the alsa mixer name
+    let _output = Command::new("amixer")
+        .args(&["set", "SoftMaster", "5%+"])
+        .output()
+        .expect("failed to increase volume via amixer");
+}
+
+/// increase the volume via alsa
+fn volume_decrease() {
+    // FIXME: do not hardcode the alsa mixer name
+    let _output = Command::new("amixer")
+        .args(&["set", "SoftMaster", "5%-"])
+        .output()
+        .expect("failed to decrease volume via amixer");
 }
 
 fn play(child: &mut Option<Child>, conf: &Config, tag: &String) {


### PR DESCRIPTION
With that, it's possible to assign the VOLUME_INCREASE and
VOLUME_DECREASE action to a tag to modify the volume.

Note: This is currently hardcoding the used alsa mixer called
"SoftMaster".