### PR TITLE
Move config module to its own file

### DIFF
--- a/src/bin/soundkid.rs
+++ b/src/bin/soundkid.rs
@@ -1,5 +1,9 @@
 extern crate clap;
 
+extern crate soundkid;
+
+use soundkid::config;
+
 use clap::{crate_version, App, Arg};
 use config::Config;
 use log::info;
@@ -135,47 +139,6 @@ fn play(child: &mut Option<Child>, conf: &Config, tag: &String) {
             .spawn()
             .expect("Unable to spawn a child process"),
     );
-}
-
-/// The config module that handles the soundkid configuration
-mod config {
-    extern crate dirs;
-
-    use log::info;
-    use serde::Deserialize;
-    use std::collections::HashMap;
-    use std::fs;
-    use std::path::PathBuf;
-
-    #[derive(Deserialize, Debug)]
-    pub struct Config {
-        pub common: ConfigCommon,
-        pub spotify: ConfigSpotify,
-        pub tags: HashMap<String, String>,
-    }
-
-    #[derive(Deserialize, Debug)]
-    pub struct ConfigCommon {
-        pub input_device_description: String,
-    }
-
-    #[derive(Deserialize, Debug)]
-    pub struct ConfigSpotify {
-        pub username: String,
-        pub password: String,
-    }
-
-    impl Config {
-        pub fn new() -> Config {
-            let mut config_file_path = PathBuf::new();
-            config_file_path.push(dirs::home_dir().unwrap());
-            config_file_path.push(".soundkid.conf");
-            info!("Trying to read config file...");
-            let yaml_content = fs::read_to_string(config_file_path.as_path()).unwrap();
-            let yaml_config: Config = serde_yaml::from_str(yaml_content.as_str()).unwrap();
-            return yaml_config;
-        }
-    }
 }
 
 /// The reader module to get input events from the NFC card reader

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,38 @@
+/// The config module that handles the soundkid configuration
+extern crate dirs;
+
+use log::info;
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+
+#[derive(Deserialize, Debug)]
+pub struct Config {
+    pub common: ConfigCommon,
+    pub spotify: ConfigSpotify,
+    pub tags: HashMap<String, String>,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct ConfigCommon {
+    pub input_device_description: String,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct ConfigSpotify {
+    pub username: String,
+    pub password: String,
+}
+
+impl Config {
+    pub fn new() -> Config {
+        let mut config_file_path = PathBuf::new();
+        config_file_path.push(dirs::home_dir().unwrap());
+        config_file_path.push(".soundkid.conf");
+        info!("Trying to read config file...");
+        let yaml_content = fs::read_to_string(config_file_path.as_path()).unwrap();
+        let yaml_config: Config = serde_yaml::from_str(yaml_content.as_str()).unwrap();
+        return yaml_config;
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod config;


### PR DESCRIPTION
That way it can be reused and the structure is a bit more clear.