### PR TITLE
Make the used alsa control configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ input:
     00000011666611330099: "RESUME"
     00000011666611330100: "VOLUME_INCREASE"
     00000011666611330101: "VOLUME_DECREASE"
+alsa:
+  control: "SoftMaster"
 spotify:
   username: "my-spotify-username"
   password: "my-secret-spotify-password"
@@ -58,6 +60,9 @@ The `input` map is similar to the `gpio` map. "HXGCoLtd Keyboard" is the key (th
 eg. `/dev/input/event15`, try `sudo evtest` to get information about the available devices) and under 
 that key is another map that contains key/value pairs of tags (in this example the values starting with 00000)
 and actions (in this example spotify uris or other actions like "PAUSE", "RESUME", ...)
+
+The `alsa` map has currently only `control` key. That's the ALSA control (try `amixer` to get a list of
+controls) to that is used to increase/decrease the volume.
 
 The `spotify` map must contain `username` and `password`.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,12 +7,17 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
 
+fn default_alsa_control() -> String {
+    return "Master".to_string();
+}
+
 #[derive(Deserialize, Debug)]
 pub struct Config {
     #[serde(default)]
     pub gpio: HashMap<String, HashMap<u32, String>>,
     #[serde(default)]
     pub input: HashMap<String, HashMap<String, String>>,
+    pub alsa: ConfigAlsa,
     pub spotify: ConfigSpotify,
 }
 
@@ -20,6 +25,12 @@ pub struct Config {
 pub struct ConfigSpotify {
     pub username: String,
     pub password: String,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct ConfigAlsa {
+    #[serde(default = "default_alsa_control")]
+    pub control: String,
 }
 
 impl Config {


### PR DESCRIPTION
It's now possible to select a different ALSA control to
increase/decrease the volume.