### PR TITLE
Search for a config file in multiple locations

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,7 @@
 /// The config module that handles the soundkid configuration
 extern crate dirs;
 
-use log::info;
+use log::{info, warn};
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::fs;
@@ -35,12 +35,34 @@ pub struct ConfigAlsa {
 
 impl Config {
     pub fn new() -> Config {
-        let mut config_file_path = PathBuf::new();
-        config_file_path.push(dirs::home_dir().unwrap());
-        config_file_path.push(".soundkid.conf");
-        info!("Trying to read config file...");
-        let yaml_content = fs::read_to_string(config_file_path.as_path()).unwrap();
-        let yaml_config: Config = serde_yaml::from_str(yaml_content.as_str()).unwrap();
-        return yaml_config;
+        let mut config_home = PathBuf::new();
+        config_home.push(dirs::home_dir().unwrap());
+        config_home.push(".soundkid.conf");
+
+        let config_global = PathBuf::from("/etc/soundkid.conf");
+
+        for c in [&config_home, &config_global].iter() {
+            info!("Trying to read config file {:?}", c);
+            let yaml_content = fs::read_to_string(c.as_path());
+            let yaml_content = match yaml_content {
+                Ok(content) => content,
+                Err(e) => {
+                    info!("Unable to read config file {:?}: {}", c, e.to_string());
+                    continue;
+                }
+            };
+            let yaml_config = serde_yaml::from_str(yaml_content.as_str());
+            match yaml_config {
+                Ok(config) => {
+                    return config;
+                }
+                Err(e) => {
+                    warn!("Unable to parse yaml from file {:?}: {}", c, e.to_string());
+                    continue;
+                }
+            };
+        }
+
+        panic!("Unable to read any config file. ciao");
     }
 }


### PR DESCRIPTION
Beside ~/.soundkid.conf, look also at /etc/soundkid.conf .
That way, there can be a global config file if the running user does
not provide a config in its HOME directory.